### PR TITLE
Add hacky multiple MC version support for a single mod

### DIFF
--- a/NEMP/mods.json
+++ b/NEMP/mods.json
@@ -586,6 +586,19 @@
             "regex" : "v(?P<version>.+?)\\((?P<mc>.+?)\\)"
         }
     },
+    "bspkrsCore-1.6.2" : {
+        "name" : "bspkrsCore",
+        "function" : "CheckHTML",
+        "version" : "",
+        "dev" : "NOT_USED",
+        "mc" : "1.6.2",
+        "change" : "NOT_USED",
+        "active" : true,
+        "html" : {
+            "url" : "http://dl.dropboxusercontent.com/u/20748481/Minecraft/1.6.2/bspkrsCore.version",
+            "regex" : "v(?P<version>.+?)\\((?P<mc>.+?)\\)"
+        }
+    },
     "CrystalWing" : {
         "function" : "CheckHTML",
         "version" : "",

--- a/NotEnoughMods_Polling.py
+++ b/NotEnoughMods_Polling.py
@@ -355,7 +355,8 @@ def list(self,name,params,channel,userdata,rank):
     bold = unichr(2)
     color = unichr(3)
     tempList = {}
-    for key in NEM.mods:
+    for key, info in NEM.mods.iteritems():
+        real_name = info.get('name', key)
         if NEM.mods[key]["active"]:
             type = ""
             mcver = NEM.mods[key]["mc"]
@@ -366,7 +367,7 @@ def list(self,name,params,channel,userdata,rank):
             
             if not mcver in tempList:
                 tempList[mcver] = []
-            tempList[mcver].append("{0}{1}".format(key,type))
+            tempList[mcver].append("{0}{1}".format(real_name,type))
     
     del mcver
     for mcver in sorted(tempList.iterkeys()):

--- a/NotEnoughMods_Polling.py
+++ b/NotEnoughMods_Polling.py
@@ -240,14 +240,18 @@ def PollingThread(self, pipe):
         NEM.mods = NEM.newMods
         NEM.InitiateVersions()
     tempList = {}
-    for mod in NEM.mods:
+    for mod, info in NEM.mods.iteritems():
+        if 'name' in info:
+            real_name = info['name']
+        else:
+            real_name = mod
         if NEM.mods[mod]["active"]:
             result = NEM.CheckMod(mod)
             if result[0]:
                 if NEM.mods[mod]["mc"] in tempList:
-                    tempList[NEM.mods[mod]["mc"]].append((mod, result[1:]))
+                    tempList[NEM.mods[mod]["mc"]].append((real_name, result[1:]))
                 else:
-                    tempVersion = [(mod, result[1:])]
+                    tempVersion = [(real_name, result[1:])]
                     tempList[NEM.mods[mod]["mc"]] = tempVersion
     pipe.send(tempList)
 def MainTimerEvent(self,channels):


### PR DESCRIPTION
Adds an optional `name` field in the JSON DB which specifies the actual name of the mod.

MC version must also be hardcoded, or it'll remain empty, as Not Enough Mods has no mod by that name on their lists.

It's hacky, but it works.
