### PR TITLE
BloodMagic file naming scheme changed as of v1.2.1

### DIFF
--- a/NEMP/mods.json
+++ b/NEMP/mods.json
@@ -504,7 +504,7 @@
         "active" : true,
         "html" : {
             "url" : "https://www.dropbox.com/sh/0aqvalqobu61t44/AADZq-GuoDeuNzgg6zueVM_Ca",
-            "regex" : "Blood Magic-v(?P<version>.+?)\\(.+?\\)\\.jar"
+            "regex" : "BloodMagic-(?P<mc>.+?)-(?P<version>.+?)-1.jar"
         }
     },
     "CreeperCollateral" : {


### PR DESCRIPTION
I'm not sure about the extra -1 in the filename (i.e. BloodMagic-1.7.10-1.2.1a-1.jar).  I think it might be a build number, but it is 1 on both 1.2.1 and 1.2.1a.
