### PR TITLE
Fixing WeaponsPlus not working

### DIFF
--- a/NEMP/mods.json
+++ b/NEMP/mods.json
@@ -4358,7 +4358,7 @@
         "active": true,
         "forgejson": {
             "url": "https://raw.githubusercontent.com/sokratis12GR/VersionUpdate/gh-pages/WeaponsPlus.json",
-            "mcversion": "1.9.4"
+            "mcversion": "1.9"
         }    	
     }
 }


### PR DESCRIPTION
for some reason the 1.9 checks for both 1.9 and 1.9.4
and 1.9.4 doesn't check anything

```
@ModBot[1.9.4] ArmorPlus updated to 2.0.1 
```

Here is the ForgeJson file: https://raw.githubusercontent.com/sokratis12GR/VersionUpdate/gh-pages/ArmorPlus.json
It checked the 1.9.4 instead of the 1.9
