### PR TITLE
Improve Regex error message

### DIFF
--- a/NEMP/NEMP_Class.py
+++ b/NEMP/NEMP_Class.py
@@ -409,7 +409,7 @@ class NotEnoughClasses():
 
                 if not match:
                     if release['id'] == latest_release_id:
-                        raise NEMPException("Regex is outdated (doesn't match against latest release). Latest: " + release['name'])
+                        raise NEMPException("Regex is outdated (doesn't match against latest release). Latest: " + release['name'] + ", Regex: " + self.get_mod_regex(mod).pattern)
 
                     # If this release isn't the latest one, we just assume it's an old one and skip it
                     continue


### PR DESCRIPTION
When seeing an error regarding an outdated regular expression, showing the regular expression that just failed would add value, as in most cases its a minor tweak that is needed instead of an overhaul.