### PR TITLE
refactor(poller): replace deprecated aiohttp.BasicAuth

### DIFF
--- a/mod_polling/poller.py
+++ b/mod_polling/poller.py
@@ -408,7 +408,8 @@ class ModPoller:
         url = "https://api.github.com/repos/" + repo + "/releases"
 
         if client_id and client_secret:
-            releases = await self.fetch_json(url, auth=aiohttp.BasicAuth(client_id, client_secret))
+            headers = {"Authorization": aiohttp.encode_basic_auth(client_id, client_secret)}
+            releases = await self.fetch_json(url, headers=headers)
         else:
             releases = await self.fetch_json(url)
 

--- a/scripts/test_regexes.py
+++ b/scripts/test_regexes.py
@@ -235,7 +235,7 @@ async def check_github_release(
 
     kwargs = {}
     if client_id and client_secret:
-        kwargs["auth"] = aiohttp.BasicAuth(client_id, client_secret)
+        kwargs["headers"] = {"Authorization": aiohttp.encode_basic_auth(client_id, client_secret)}
 
     async with session.get(url, **kwargs) as resp:
         if resp.status >= 400:


### PR DESCRIPTION
## What

Replace the deprecated `aiohttp.BasicAuth` with `aiohttp.encode_basic_auth()`, building the `Authorization` header directly.

## Why

aiohttp 3.14 deprecates `aiohttp.BasicAuth`, slated for removal in aiohttp 4.0. The 3.14.0 upgrade in #321 surfaced this as a `DeprecationWarning`; this is the follow-up noted there.

## Changes

- `mod_polling/poller.py`: GitHub release auth now passes `headers={"Authorization": aiohttp.encode_basic_auth(...)}`
- `scripts/test_regexes.py`: same swap in the regex-testing maintenance script

Behavior is unchanged: `encode_basic_auth` emits the identical `Basic <base64(id:secret)>` value for the ASCII GitHub credentials in use.

## Verification

`uv run pytest` reports 200 passed with the `BasicAuth` DeprecationWarning gone (the warnings summary is now empty); `ruff check` and `ruff format --check` are clean.
